### PR TITLE
Fixed an issue with case sensitivity in column defs

### DIFF
--- a/src/Model/Config/Source/OrderAttributes.php
+++ b/src/Model/Config/Source/OrderAttributes.php
@@ -53,6 +53,10 @@ class OrderAttributes extends Attributes implements OptionSourceInterface
             $this->orderResource->getMainTable()
         );
         foreach ($queryResult->fetchAll() as $columnDef) {
+            $columnDef = array_combine(
+                array_map('strtolower', array_keys($columnDef)),
+                array_values($columnDef)
+            );
             if (in_array($columnDef['column_name'], $attributeCodes, true)) {
                 continue;
             }


### PR DESCRIPTION
Hi,

There seems to be an issue with case sensitivity when accessing column definitions. To avoid this from happening this (minor) patch maps the keys of the definition array to lowercase.

I'm unsure whether other developers have encountered this issue, since its caused by the filesystem this code is run on. The filesystem we are using is case-sensitive causing `undefined index` errors, since `COLUMN_NAME` and `column_name` is not an exact match.

The error produced with the original code:
`[2021-07-26 09:16:33] .CRITICAL: Notice: Undefined index: column_name in /xxx/vendor/emico/magento-2-robinhq/src/Model/Config/Source/OrderAttributes.php on line 56 {"exception":"[object] (Exception(code: 0): Notice: Undefined index: column_name in /xxx/vendor/emico/magento-2-robinhq/src/Model/Config/Source/OrderAttributes.php on line 56 at /xxx/vendor/magento/framework/App/ErrorHandler.php:61)"} []`