### PR TITLE
Allow custom attributes to be empty

### DIFF
--- a/src/etc/adminhtml/system.xml
+++ b/src/etc/adminhtml/system.xml
@@ -63,14 +63,17 @@
                 <label>Custom Attributes</label>
                 <field id="customer_attributes" translate="Module" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Customer attributes</label>
+                    <can_be_empty>1</can_be_empty>
                     <source_model>Emico\RobinHq\Model\Config\Source\CustomerAttributes</source_model>
                 </field>
                 <field id="product_attributes" translate="Module" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Product attributes</label>
+                    <can_be_empty>1</can_be_empty>
                     <source_model>Emico\RobinHq\Model\Config\Source\ProductAttributes</source_model>
                 </field>
                 <field id="order_attributes" translate="Module" type="multiselect" sortOrder="30" showInDefault="1" showInWebsite="1" showInStore="1">
                     <label>Order attributes</label>
+                    <can_be_empty>1</can_be_empty>
                     <source_model>Emico\RobinHq\Model\Config\Source\OrderAttributes</source_model>
                 </field>
             </group>


### PR DESCRIPTION
You can not unselect all options if can_be_empty is not set.