### PR TITLE
Fix "Undefined index: column_name" when opening admin settings

### DIFF
--- a/src/Model/Config/Source/OrderAttributes.php
+++ b/src/Model/Config/Source/OrderAttributes.php
@@ -59,6 +59,7 @@ class OrderAttributes extends Attributes implements OptionSourceInterface
             ->where('table_name = ?', $this->orderResource->getMainTable());
         $queryResult = $connection->query($select);
         foreach ($queryResult->fetchAll() as $columnDef) {
+            $columnDef = array_change_key_case($columnDef, CASE_LOWER);
             $this->columns[$columnDef['column_name']] = $columnDef['column_comment'];
         }
 


### PR DESCRIPTION
In some cases the columnDef array would use uppercase for it's keys, as in:

```
Array (
 [COLUMN_NAME] => entity_id
 [COLUMN_COMMENT] => Entity ID
)
```

This commit makes sure the keys are converted to lowercase for before comparison.