### PR TITLE
php8.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "OSL-3.0",
     "description": "Magento 2 module for RobinHQ integration. Provides API endpoints for RobinHQ dynamic API",
     "require": {
-        "php": ">=7.4 <8.2",
+        "php": ">=7.4 <=8.2",
         "emico/robinhq-lib": "^1.0.6|^2.0",
         "magento/module-customer": "101.*|102.*|103.*",
         "magento/module-catalog": "102.*|103.*|104.*",


### PR DESCRIPTION
I just run some phpcs tests to check if the code is compatible with 8.2 and it all passes. 

So if you can accept this PR and tag a new version, it will also work with magento 2.4.6 on php8.2