### PR TITLE
Magento 2.4.6 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "magento/module-sales": "101.*|102.*|103.*",
         "magento/module-config": "101.*",
         "magento/framework": "101.*|102.*|103.*",
-        "laminas/laminas-diactoros": "^2.0",
+        "laminas/laminas-diactoros": "^3.2",
         "webmozart/assert": "^1.4",
         "ext-json": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "magento/module-sales": "101.*|102.*|103.*",
         "magento/module-config": "101.*",
         "magento/framework": "101.*|102.*|103.*",
-        "laminas/laminas-diactoros": "^3.2",
+        "laminas/laminas-diactoros": "^2.0|^3.0",
         "webmozart/assert": "^1.4",
         "ext-json": "*"
     },


### PR DESCRIPTION
@bramstroker I've updated the laminas/laminas-diactoros require version as it blocked it from installing by composer. Including the module in app/code didn't show any problems.