### PR TITLE
PHP 8.3 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "license": "OSL-3.0",
     "description": "Magento 2 module for RobinHQ integration. Provides API endpoints for RobinHQ dynamic API",
     "require": {
-        "php": ">=8.0 <=8.3",
+        "php": ">=8.0 <=8.4",
         "emico/robinhq-lib": "^4.0",
         "magento/module-customer": "101.*|102.*|103.*",
         "magento/module-catalog": "102.*|103.*|104.*",
@@ -28,8 +28,8 @@
         }
     },
     "require-dev": {
-        "codeception/codeception": "^3.1",
-        "mockery/mockery": "^1.2"
+        "codeception/codeception": "^5.1",
+        "mockery/mockery": "^1.6"
     },
     "repositories": {
         "magento": {


### PR DESCRIPTION
Hi,

Bumped the PHP version to support 8.3 and ran static code analysis. No noteworthy errors.

I had to update the dev dependencies to newer versions though. This change might break the tests. I've checked the tests' configuration and found it only tests against PHP version 7.3 and 7.4. They will fail anyway with v4 since the package doesn't even support these version anymore.